### PR TITLE
Update README with project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,49 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+# Blog Miracle Frontend
 
-## Available Scripts
+一个使用 React 构建的博客前端项目，包含访客端浏览体验和简单的后台文章管理能力。页面路由通过 `HashRouter` 组织，公共头尾由 `App` 组件统一提供。
 
-In the project directory, you can run:
+## 功能概览
+- **首页轮播与最新文章**：`/` 与 `/blog/index` 展示头图轮播、最新发布文章列表、日常短句及热门文章推荐。
+- **文章浏览**：`/blog/articles` 分页查看文章列表，`/blog/article/:id` 查看文章详情并支持评论组件（见 `src/page/Component`）。
+- **站点信息**：友链页 `/blog/links`、关于页 `/blog/abouts`、时间线页 `/blog/timeline` 等静态信息入口。
+- **后台文章编辑**：登录后访问 `/admin/editor` 使用富文本编辑器（基于 `wangeditor`）发布或置顶文章；无 token 会被重定向到登录页。
 
-### `npm start`
+## 技术栈
+- React 16 + React Router 5 (`HashRouter` + `Switch` 路由结构)
+- Ant Design 组件库
+- Axios 封装的 HTTP 工具（`src/utils/HttpUtil.js`），默认请求前缀为 `https://www.miracle1874.com/api`，请求头自动附带本地存储的 `token`
+- 自定义样式与轮播、文章预览等组件位于 `src/page/Component`
 
-Runs the app in the development mode.<br />
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+## 开发与构建
+1. 安装依赖：
+   ```bash
+   npm install
+   ```
+2. 本地开发：
+   ```bash
+   npm start
+   ```
+   运行自定义脚本 `scripts/start.js`，默认在 [http://localhost:3000](http://localhost:3000) 提供开发服务器。
+3. 生产构建：
+   ```bash
+   npm run build
+   ```
+   输出编译后的静态资源到 `build/` 目录。
 
-The page will reload if you make edits.<br />
-You will also see any lint errors in the console.
+## 路由入口
+`src/router/BlogRouter.jsx` 定义了所有路由与布局关系：
+- `App` 包裹公共头部 (`Header`) 与底部 (`Footer`)
+- 访客端：`/blog/index`、`/blog/links`、`/blog/abouts`、`/blog/timeline`、`/blog/articles`、`/blog/article/:id`
+- 管理端：`/login`、`/admin/editor`（受 token 控制）
 
-### `npm test`
+## API 与鉴权
+- 请求封装位于 `src/utils/HttpUtil.js`，统一处理超时、请求头和基础地址。
+- 管理端登录 (`/admin/login`) 成功后会将后端返回的 token 写入 `localStorage`，之后的接口请求会自动携带 `Authorization` 头。
+- 验证码地址与接口域名在组件内写死，如需调整请同步修改 HTTP 工具前缀。
 
-Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+## 文件结构提示
+- 页面与功能组件：`src/page/**/*`
+- 样式与静态资源：`src/css/`、`src/fonts/`、`src/images/`
+- 路由与应用入口：`src/router/BlogRouter.jsx`、`src/index.js`
 
-### `npm run build`
-
-Builds the app for production to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.<br />
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
-
-### Analyzing the Bundle Size
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
-
-### Making a Progressive Web App
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
-
-### Advanced Configuration
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
-
-### Deployment
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
-
-### `npm run build` fails to minify
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify
+欢迎根据需要扩展组件或调整 API 地址，提交前请确保构建与 lint 通过。


### PR DESCRIPTION
## Summary
- replace the default Create React App README with documentation tailored to the blog frontend
- document main routes, features, tech stack, and HTTP configuration
- add concise development and build instructions for the project scripts

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69202abaf0c8832aa8eb50366d7778ac)